### PR TITLE
Endpoint for Transcribe in T-PEN

### DIFF
--- a/Source Packages/java/edu/slu/tpen/servlet/GetProjectTPENServlet.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/GetProjectTPENServlet.java
@@ -99,7 +99,6 @@ public class GetProjectTPENServlet extends HttpServlet {
 //                    System.out.println("group Id ===== " + proj.getGroupID() + " is member " + group.isMember(uid));
                     if (group.isMember(uid) || isTPENAdmin) {
                         if (checkModified(request, proj)) {
-                            
                             jsonMap.put("project", gson.toJson(proj));
 //                            System.out.println("project json ====== " + gson.toJson(proj));
                             int projectID = proj.getProjectID();

--- a/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
@@ -4,6 +4,8 @@
  */
 package edu.slu.tpen.servlet;
 
+import edu.slu.tpen.entity.Image.Canvas;
+import edu.slu.tpen.servlet.util.CreateAnnoListUtil;
 import edu.slu.util.ServletUtils;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
@@ -11,14 +13,21 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.sql.Connection;
 import java.sql.SQLException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
+import textdisplay.Folio;
 import textdisplay.Project;
 import tokens.TokenManager;
 import user.User;
@@ -41,93 +50,63 @@ public class TranscribeRouter extends HttpServlet {
     protected void processRequest(HttpServletRequest req, HttpServletResponse resp)
             throws ServletException, IOException, SQLException {
         System.out.println("In /transcribe router");
-        String paleoObj = "";
+        String projectName = "";
         int uid = ServletUtils.getUID(req, resp);
         boolean skip = true;
+        String redirectURL = "";
+        Project proj = null;
+        String interfaceLink = "";
         TokenManager man = new TokenManager();
+        int folioNum = -1;
         //If you choose not to automatically skip, put some method here to define what makes skip true.
         resp.addHeader("Access-Control-Allow-Origin", "*");
         resp.addHeader("Access-Control-Allow-Methods", "GET");
         System.out.println("UID detected is "+uid);
         if (uid >= 0) {
-            paleoObj = req.getPathInfo().substring(1);
-            System.out.println("Name of proj is '"+paleoObj+"'");
-            //paleoObj = req.getParameter("name");
+            projectName = req.getPathInfo().substring(1);
+            System.out.println("Name of proj is '"+projectName+"'");
+            //projectName = req.getParameter("name");
             User lookup = new User(uid);
-            Project proj = lookup.getUserProjectForPaleoObject(paleoObj);         
+            proj = lookup.getUserProjectForPaleoObject(projectName);         
             if (null != proj && proj.getProjectID() > 0) {
                 //Then this user has a project already.  Redirect to that project.
                 System.out.println("Found existing project for user: "+proj.getProjectID());
-                int folioNum = proj.firstPage();
-                String interfaceLink = "";
+                folioNum = proj.firstPage();
                 if(folioNum > -1){
                    interfaceLink = proj.mintInterfaceLinkFromFolio(folioNum);
+                   resp.sendRedirect(man.getProperties().getProperty("SERVERURL")+interfaceLink);
                 }
-                String redirectURL = man.getProperties().getProperty("SERVERURL")+interfaceLink;
-                resp.sendRedirect(redirectURL);
+                else{
+                    System.out.println("Could not mint interface link.  There was no folio.");
+                    resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                }
             } 
             else{
                 //This user did not have a project yet.  Get the master project ID, run /copyProject, and redirect to the resulting link
-                System.out.println("TODO run copy project and redirect to resulting ID");  
-                resp.sendError(HttpServletResponse.SC_NOT_FOUND);
-                int masterID = Project.getMasterProjectID(paleoObj);
+                int masterID = Project.getMasterProjectID(projectName);
                 System.out.println("Is this the right masterID? '"+masterID+"'");
-                
-                /*
-                URL postUrl = new URL(man.getProperties().getProperty("SERVERURL")+"copyProjectAndTranscription?projectID="+masterID); //copyProjectAndLineParsing
-                HttpURLConnection connection = (HttpURLConnection) postUrl.openConnection();
-                connection.setDoOutput(true);
-                connection.setDoInput(true);
-                connection.setRequestMethod("POST");
-                connection.setUseCaches(false);
-                connection.setInstanceFollowRedirects(true);
-                connection.setRequestProperty("Content-Type", "application/json; charset=utf-8");
-                connection.connect();
-                DataOutputStream out = new DataOutputStream(connection.getOutputStream());
-                out.flush();
-                out.close(); 
-                boolean er = false;
-                StringBuilder sb = new StringBuilder();
-                try{
-                    BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(),"utf-8"));
-                    String line="";
-                    while ((line = reader.readLine()) != null){
-                        line = new String(line.getBytes(), "utf-8");
-                        sb.append(line);
-                    }
-                    reader.close();
-                    System.out.println("Copy project has finished for router");
-                    System.out.println(sb.toString());
-                    System.out.println(Integer.parseInt(sb.toString().replace(man.getProperties().getProperty("CREATE_PROJECT_RETURN_DOMAIN")+"project/", "")));
-                    Project resultingProject = new Project(Integer.parseInt(sb.toString().replace(man.getProperties().getProperty("CREATE_PROJECT_RETURN_DOMAIN")+"project/", "")));
-                    int folioNum = resultingProject.firstPage();
-                    String interfaceLink = "";
+                int copiedProjectID = copyProjectAndTranscription(uid, masterID, req.getLocalName());
+                if(copiedProjectID > 0){
+                    proj = new Project(copiedProjectID);
+                    folioNum = proj.firstPage();
                     if(folioNum > -1){
                        interfaceLink = proj.mintInterfaceLinkFromFolio(folioNum);
+                       resp.sendRedirect(man.getProperties().getProperty("SERVERURL")+interfaceLink);
                     }
-                    String redirectURL = "http://paleo.rerum.io/TPEN-NL/"+interfaceLink;
-                    resp.sendRedirect(redirectURL);
+                    else{
+                        System.out.println("Could not mint interface link.  There was no folio.  Redirect not possible.");
+                        resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                    }
                 }
-                catch (IOException ex){
-                    //Copy Project Error
-                    System.out.println("Copy Project Error in Transcribe Router...");
-                    BufferedReader error = new BufferedReader(new InputStreamReader(connection.getErrorStream(),"utf-8"));
-                    String errorLine = "";
-                    while ((errorLine = error.readLine()) != null){  
-                        sb.append(errorLine);
-                    } 
-                    error.close();
-                    er = true;
-                    System.out.println(sb.toString());
+                else{
+                    System.out.println("Could not copy project.  Redirect not possible.");
+                    resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 }
-                finally{
-                    connection.disconnect();
-                }
-                */
             }
         } 
         else {
             /* They need to be logged into T-PEN to run this! */
+            System.out.println("You must be logged in to activate the /transcribe router!");
             resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         }
     }
@@ -179,4 +158,397 @@ public class TranscribeRouter extends HttpServlet {
         return "Short description";
     }// </editor-fold>
 
+    //copyProjectAndTranscriptions
+    private int copyProjectAndTranscription(int uID, int projectID, String localName){
+        int result = -1;
+        boolean er = false;
+        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS");
+        Date date = new Date();
+        //System.out.println("Copying at "+dateFormat.format(date));    
+        //System.out.println("Copy project and annos for "+projectID);
+        try {
+            //find original project and copy to a new project. 
+            Project templateProject = new Project(projectID);
+            Connection conn = ServletUtils.getDBConnection();
+            conn.setAutoCommit(false);
+            //in this method, it copies everything about the project.
+            if(null != templateProject.getProjectName())
+            {
+                Project thisProject = new Project(templateProject.copyProjectWithoutTranscription(conn, uID));
+                TokenManager man = new TokenManager();
+                //set partner project. It is to make a connection on switch board. 
+                thisProject.setAssociatedPartnerProject(projectID);
+                //^^copyProjectWithoutTranscription does special chars and XML 
+                conn.commit();
+                Folio[] folios = thisProject.getFolios();
+                //System.out.println("Created a new project template.  What was the ID assigned to it: "+thisProject.getProjectID());
+                if(null != folios && folios.length > 0)
+                {
+                    for(int i = 0; i < folios.length; i++)
+                    {
+                        //System.out.println("Starting copy for canvas");
+                        Folio folio = folios[i];
+                        String imageURL = folio.getImageURL();
+                        // use regex to extract paleography pid
+                        //THIS MUST MATCH THE NAMING CONVENTION IN JSONLDEXporter
+                        String canvasID = man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1"); //for paleo
+                        JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasID, uID, man);
+                        JSONObject jo_annotationList = new JSONObject();
+                        //^^ this does all the filtering and will either have 0 or 1 lists for this particular version of TPEN
+                        if(!ja_allAnnoLists.isEmpty()){
+                            jo_annotationList = ja_allAnnoLists.getJSONObject(0); 
+                        }
+                        JSONArray new_resources = new JSONArray();
+                        JSONArray resources = new JSONArray();
+                        String parseThis;
+                        String pubTok = man.getAccessToken();
+                        boolean expired = man.checkTokenExpiry();
+                        if(expired){
+                            System.out.println("TPEN_NL Token Manager detected an expired token, auto getting and setting a new one...");
+                            pubTok = man.generateNewAccessToken();
+                        }
+                        if(!jo_annotationList.isEmpty() && (null != jo_annotationList.get("resources") && !jo_annotationList.get("resources").toString().equals("[]"))){
+                            try{
+                                resources = (JSONArray) jo_annotationList.get("resources");
+                            }
+                            catch(JSONException e){
+                                System.out.println("List we found could not be parsed, so we are defaulting with an empty list.");
+                                //If this list can't be parsed, the copied list will have errors.  Just define it as empty as the fail.  
+                            }
+                            //add testing flag before passing off
+                            for(int h=0; h<resources.size(); h++){
+                                resources.getJSONObject(h).element("TPEN_NL_TESTING", man.getProperties().getProperty("TESTING"));
+                                resources.getJSONObject(h).element("oa:createdBy", localName + "/" + uID);
+                                resources.getJSONObject(h).remove("_id");
+                                resources.getJSONObject(h).remove("@id");
+                                resources.getJSONObject(h).remove("addedTime");
+                                resources.getJSONObject(h).remove("originalAnnoID");
+                                resources.getJSONObject(h).remove("version");
+                                resources.getJSONObject(h).remove("permission");
+                                resources.getJSONObject(h).remove("forkFromID"); // retained for legacy v0 objects
+                                resources.getJSONObject(h).remove("serverName");
+                                resources.getJSONObject(h).remove("serverIP");
+                            }
+
+                            URL postUrlCopyAnno = new URL(Constant.ANNOTATION_SERVER_ADDR + "/batch_create.action");
+                            HttpURLConnection ucCopyAnno = (HttpURLConnection) postUrlCopyAnno.openConnection();
+                            ucCopyAnno.setDoInput(true);
+                            ucCopyAnno.setDoOutput(true);
+                            ucCopyAnno.setRequestMethod("POST");
+                            ucCopyAnno.setUseCaches(false);
+                            ucCopyAnno.setInstanceFollowRedirects(true);
+                            ucCopyAnno.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+                            ucCopyAnno.setRequestProperty("Authorization", "Bearer "+pubTok);
+                            ucCopyAnno.connect();
+                            DataOutputStream dataOutCopyAnno = new DataOutputStream(ucCopyAnno.getOutputStream());
+                            String str_resources = "";
+                            if(resources.size() > 0){
+                                str_resources = resources.toString();
+                            }
+                            else{
+                                str_resources = "[]";
+                            }
+//                                System.out.println("Batch create these");
+//                                System.out.println(str_resources);
+                            byte[] toWrite = str_resources.getBytes("UTF-8");
+                            dataOutCopyAnno.write(toWrite);
+                            dataOutCopyAnno.flush();
+                            dataOutCopyAnno.close();
+                            String lines = "";
+                            StringBuilder sbAnnoLines = new StringBuilder();
+                            try{
+                                BufferedReader returnedAnnoList = new BufferedReader(new InputStreamReader(ucCopyAnno.getInputStream(),"utf-8"));
+                                while ((lines = returnedAnnoList.readLine()) != null){
+    //                                    System.out.println(lineAnnoLs);
+                                    sbAnnoLines.append(lines);
+                                }
+                                returnedAnnoList.close();
+                            }
+                            catch (IOException ex){
+                                //Forward error response from RERUM
+                                BufferedReader error = new BufferedReader(new InputStreamReader(ucCopyAnno.getErrorStream(),"utf-8"));
+                                String errorLine = "";
+                                StringBuilder sb = new StringBuilder();
+                                while ((errorLine = error.readLine()) != null){  
+                                    sb.append(errorLine);
+                                } 
+                                error.close();
+                                result = -1;
+                                er = true;
+                                break;
+                            }
+                            ucCopyAnno.disconnect();
+                            parseThis = sbAnnoLines.toString();                              
+                            JSONObject batchSaveResponse = JSONObject.fromObject(parseThis);
+                            try{
+                                new_resources = (JSONArray) batchSaveResponse.get("new_resources");
+                            }
+                            catch(JSONException e){
+                               System.out.println("Batch save response does not contain JSONARRAY in new_resouces.");
+                               result = -1;
+                               er = true;
+                               break;
+                            }
+                        }
+                        else{
+                            //System.out.println("No annotation list for this canvas.  do not call batch save.  just save empty list.");
+                        }
+                        JSONObject canvasList = CreateAnnoListUtil.createAnnoList(thisProject.getProjectID(), canvasID, man.getProperties().getProperty("TESTING"), new_resources, uID, localName);
+                        canvasList.element("copiedFrom", projectID);
+                        URL postUrl = new URL(Constant.ANNOTATION_SERVER_ADDR + "/create.action");
+                        HttpURLConnection uc = (HttpURLConnection) postUrl.openConnection();
+                        uc.setDoInput(true);
+                        uc.setDoOutput(true);
+                        uc.setRequestMethod("POST");
+                        uc.setUseCaches(false);
+                        uc.setInstanceFollowRedirects(true);
+                        uc.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+                        uc.setRequestProperty("Authorization", "Bearer "+pubTok);
+                        uc.connect();
+                        DataOutputStream dataOut = new DataOutputStream(uc.getOutputStream());
+                        byte[] toWrite2 = canvasList.toString().getBytes("UTF-8");
+                        dataOut.write(toWrite2);
+                        dataOut.flush();
+                        dataOut.close();
+                        try{
+                            BufferedReader reader = new BufferedReader(new InputStreamReader(uc.getInputStream(),"utf-8")); 
+                            reader.close();
+                            uc.disconnect();
+                        }
+                        catch (IOException ex){
+                            //forward error response from rerum
+                            BufferedReader error = new BufferedReader(new InputStreamReader(uc.getErrorStream(),"utf-8"));
+                            String errorLine = "";
+                            StringBuilder sb = new StringBuilder();
+                            while ((errorLine = error.readLine()) != null){  
+                                sb.append(errorLine);
+                            } 
+                            error.close();
+                            System.out.println(sb.toString());
+                            result = -1;
+                            er = true;
+                            break;
+                        }
+
+                        //System.out.println("Finished this canvas.");
+                    }
+                }
+                //System.out.println("Copy isPartOf and annos finished.  Whats the ID to return: "+thisProject.getProjectID());
+                if(!er){
+                    result = thisProject.getProjectID();
+                }
+                else{
+                    result = -1;
+                    System.out.println("There was an error.  Copy Project was not performed successfully");
+                }
+            }
+            else{
+                System.out.println("Could not get a project name, this is an error.");
+                result = -1;
+            }
+        } 
+        catch(Exception e){
+            System.out.println("Exception Caught.  Could not copy project.");
+            result = -1;
+            System.out.println(e.getStackTrace());
+        }
+        return result;
+    }
+    
+    private int copyProjectAndLineParsing(int uID, int projectID, String localName){
+        int result = -1;
+        int codeOverwrite = 500;
+        boolean er = false;
+        try {
+            //find original project and copy to a new project. 
+            Project templateProject = new Project(projectID);
+            Connection conn = ServletUtils.getDBConnection();
+            conn.setAutoCommit(false);
+            //in this method, it copies everything about the project.
+            if(null != templateProject.getProjectName())
+            {
+                Project thisProject = new Project(templateProject.copyProjectWithoutTranscription(conn, uID));
+                TokenManager man = new TokenManager();
+                //set partner project. It is to make a connection on switch board. 
+                thisProject.setAssociatedPartnerProject(projectID);
+                //^^copyProjectWithoutTranscription does special chars and XML 
+                conn.commit();
+                Folio[] folios = thisProject.getFolios();
+                //System.out.println("Created a new project template.  What was the ID assigned to it: "+thisProject.getProjectID());
+                if(null != folios && folios.length > 0)
+                {
+                    for(int i = 0; i < folios.length; i++)
+                    {
+                        //System.out.println("Starting copy for canvas");
+                        Folio folio = folios[i];
+                        String imageURL = folio.getImageURL();
+                        // use regex to extract paleography pid
+                        //THIS MUST MATCH THE NAMING CONVENTION IN JSONLDEXporter
+                        String canvasID = man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1"); //for paleo
+                        JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasID, uID, man);
+                        JSONObject jo_annotationList = new JSONObject();
+                        //^^ this does all the filtering and will either have 0 or 1 lists for this particular version of TPEN
+                        if(!ja_allAnnoLists.isEmpty()){
+                            jo_annotationList = ja_allAnnoLists.getJSONObject(0); 
+                        }
+                        JSONArray new_resources = new JSONArray();
+                        JSONArray resources = new JSONArray();
+                        String parseThis;
+                        String pubTok = man.getAccessToken();
+                        boolean expired = man.checkTokenExpiry();
+                        if(expired){
+                            System.out.println("TPEN_NL Token Manager detected an expired token, auto getting and setting a new one...");
+                            pubTok = man.generateNewAccessToken();
+                        }
+                        if(!jo_annotationList.isEmpty() && (null != jo_annotationList.get("resources") && !jo_annotationList.get("resources").toString().equals("[]"))){
+                            try{
+                                resources = (JSONArray) jo_annotationList.get("resources");
+                            }
+                            catch(JSONException e){
+                                System.out.println("List we found could not be parsed, so we are defaulting with an empty list.");
+                                //If this list can't be parsed, the copied list will have errors.  Just define it as empty as the fail.  
+                            }
+                            //add testing flag before passing off
+                            for(int h=0; h<resources.size(); h++){
+                                resources.getJSONObject(h).element("TPEN_NL_TESTING", man.getProperties().getProperty("TESTING"));
+                                resources.getJSONObject(h).element("oa:createdBy", localName + "/" + uID);
+                                //Event empty lines have a resource, if it is ours it should be there.
+                                if(resources.getJSONObject(h).has("resource")){
+                                    resources.getJSONObject(h).getJSONObject("resource").element("cnt:chars", "");
+                                }
+                                resources.getJSONObject(h).remove("_id");
+                                resources.getJSONObject(h).remove("@id");
+                                resources.getJSONObject(h).remove("addedTime");
+                                resources.getJSONObject(h).remove("originalAnnoID");
+                                resources.getJSONObject(h).remove("version");
+                                resources.getJSONObject(h).remove("permission");
+                                resources.getJSONObject(h).remove("forkFromID"); // retained for legacy v0 objects
+                                resources.getJSONObject(h).remove("serverName");
+                                resources.getJSONObject(h).remove("serverIP");
+                            }
+                            URL postUrlCopyAnno = new URL(Constant.ANNOTATION_SERVER_ADDR + "/batch_create.action");
+                            HttpURLConnection ucCopyAnno = (HttpURLConnection) postUrlCopyAnno.openConnection();
+                            ucCopyAnno.setDoInput(true);
+                            ucCopyAnno.setDoOutput(true);
+                            ucCopyAnno.setRequestMethod("POST");
+                            ucCopyAnno.setUseCaches(false);
+                            ucCopyAnno.setInstanceFollowRedirects(true);
+                            ucCopyAnno.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+                            ucCopyAnno.setRequestProperty("Authorization", "Bearer "+pubTok);
+                            ucCopyAnno.connect();
+                            DataOutputStream dataOutCopyAnno = new DataOutputStream(ucCopyAnno.getOutputStream());
+                            String str_resources = "";
+                            if(resources.size() > 0){
+                                str_resources = resources.toString();
+                            }
+                            else{
+                                str_resources = "[]";
+                            }
+//                                System.out.println("Batch create these");
+//                                System.out.println(str_resources);
+                            byte[] toWrite = str_resources.getBytes("UTF-8");
+                            dataOutCopyAnno.write(toWrite);
+                            dataOutCopyAnno.flush();
+                            dataOutCopyAnno.close();
+                            codeOverwrite = ucCopyAnno.getResponseCode();
+                            String lines = "";
+                            StringBuilder sbAnnoLines = new StringBuilder();
+                            try{
+                                BufferedReader returnedAnnoList = new BufferedReader(new InputStreamReader(ucCopyAnno.getInputStream(),"utf-8"));
+                                while ((lines = returnedAnnoList.readLine()) != null){
+    //                                    System.out.println(lineAnnoLs);
+                                    sbAnnoLines.append(lines);
+                                }
+                                returnedAnnoList.close();
+                            }
+                            catch (IOException ex){
+                                //Forward error response from RERUM
+                                BufferedReader error = new BufferedReader(new InputStreamReader(ucCopyAnno.getErrorStream(),"utf-8"));
+                                String errorLine = "";
+                                StringBuilder sb = new StringBuilder();
+                                while ((errorLine = error.readLine()) != null){  
+                                    sb.append(errorLine);
+                                } 
+                                error.close();
+                                System.out.println(sb.toString());
+                                result = -1;
+                                er = true;
+                                break;
+                            }
+                            ucCopyAnno.disconnect();
+                            parseThis = sbAnnoLines.toString();                              
+                            JSONObject batchSaveResponse = JSONObject.fromObject(parseThis);
+                            try{
+                                new_resources = (JSONArray) batchSaveResponse.get("new_resources");
+
+                            }
+                            catch(JSONException e){
+                               System.out.println("Batch save response does not contain JSONARRAY in new_resouces.");
+                               result = -1;
+                               er = true;
+                               break;
+                            }
+                        }
+                        else{
+                            //System.out.println("No annotation list for this canvas.  do not call batch save.  just save empty list.");
+                        }
+                        JSONObject canvasList = CreateAnnoListUtil.createAnnoList(thisProject.getProjectID(), canvasID, man.getProperties().getProperty("TESTING"), new_resources, uID, localName);
+                        canvasList.element("copiedFrom", projectID);
+                        URL postUrl = new URL(Constant.ANNOTATION_SERVER_ADDR + "/create.action");
+                        HttpURLConnection uc = (HttpURLConnection) postUrl.openConnection();
+                        uc.setDoInput(true);
+                        uc.setDoOutput(true);
+                        uc.setRequestMethod("POST");
+                        uc.setUseCaches(false);
+                        uc.setInstanceFollowRedirects(true);
+                        uc.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+                        uc.setRequestProperty("Authorization", "Bearer "+pubTok);
+                        uc.connect();
+                        DataOutputStream dataOut = new DataOutputStream(uc.getOutputStream());
+                        byte[] toWrite2 = canvasList.toString().getBytes("UTF-8");
+                        dataOut.write(toWrite2);
+                        dataOut.flush();
+                        dataOut.close();
+                        codeOverwrite = uc.getResponseCode();
+                        try{
+                            BufferedReader reader = new BufferedReader(new InputStreamReader(uc.getInputStream(),"utf-8")); 
+                            reader.close();
+                            uc.disconnect();
+                        }
+                        catch (IOException ex){
+                            //forward error response from ererum
+                            BufferedReader error = new BufferedReader(new InputStreamReader(uc.getErrorStream(),"utf-8"));
+                            String errorLine = "";
+                            StringBuilder sb = new StringBuilder();
+                            while ((errorLine = error.readLine()) != null){  
+                                sb.append(errorLine);
+                            } 
+                            error.close();
+                            System.out.println(sb.toString());
+                            result = -1;
+                            er = true;
+                            break;
+                        }
+
+                        //System.out.println("Finished this canvas.");
+                    }
+                }
+                //System.out.println("Copy isPartOf and annos finished.  Whats the ID to return: "+thisProject.getProjectID());
+                if(!er){
+                    result =  thisProject.getProjectID();
+                }
+            }
+            else{
+                System.out.println("Could not get a project name, this is an error.");
+                result = -1;
+            }
+        } 
+        catch(Exception e){
+            e.printStackTrace();
+            System.out.println(e.getMessage());
+        }
+        return result;
+    }
+
 }
+

--- a/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import net.sf.json.JSONObject;
 import textdisplay.Project;
+import tokens.TokenManager;
 import user.User;
 
 /**
@@ -43,6 +44,7 @@ public class TranscribeRouter extends HttpServlet {
         String paleoObj = "";
         int uid = ServletUtils.getUID(req, resp);
         boolean skip = true;
+        TokenManager man = new TokenManager();
         //If you choose not to automatically skip, put some method here to define what makes skip true.
         resp.addHeader("Access-Control-Allow-Origin", "*");
         resp.addHeader("Access-Control-Allow-Methods", "GET");
@@ -61,7 +63,7 @@ public class TranscribeRouter extends HttpServlet {
                 if(folioNum > -1){
                    interfaceLink = proj.mintInterfaceLinkFromFolio(folioNum);
                 }
-                String redirectURL = "http://paleo.rerum.io/TPEN-NL/"+interfaceLink;
+                String redirectURL = man.getProperties().getProperty("SERVERURL")+interfaceLink;
                 resp.sendRedirect(redirectURL);
             } 
             else{
@@ -69,7 +71,10 @@ public class TranscribeRouter extends HttpServlet {
                 System.out.println("TODO run copy project and redirect to resulting ID");  
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 int masterID = Project.getMasterProjectID(paleoObj);
-                URL postUrl = new URL("http://paleo.rerum.io/TPEN-NL/copyProjectAndTranscription?projectID="+masterID); //copyProjectAndLineParsing
+                System.out.println("Is this the right masterID? '"+masterID+"'");
+                
+                /*
+                URL postUrl = new URL(man.getProperties().getProperty("SERVERURL")+"copyProjectAndTranscription?projectID="+masterID); //copyProjectAndLineParsing
                 HttpURLConnection connection = (HttpURLConnection) postUrl.openConnection();
                 connection.setDoOutput(true);
                 connection.setDoInput(true);
@@ -91,6 +96,17 @@ public class TranscribeRouter extends HttpServlet {
                         sb.append(line);
                     }
                     reader.close();
+                    System.out.println("Copy project has finished for router");
+                    System.out.println(sb.toString());
+                    System.out.println(Integer.parseInt(sb.toString().replace(man.getProperties().getProperty("CREATE_PROJECT_RETURN_DOMAIN")+"project/", "")));
+                    Project resultingProject = new Project(Integer.parseInt(sb.toString().replace(man.getProperties().getProperty("CREATE_PROJECT_RETURN_DOMAIN")+"project/", "")));
+                    int folioNum = resultingProject.firstPage();
+                    String interfaceLink = "";
+                    if(folioNum > -1){
+                       interfaceLink = proj.mintInterfaceLinkFromFolio(folioNum);
+                    }
+                    String redirectURL = "http://paleo.rerum.io/TPEN-NL/"+interfaceLink;
+                    resp.sendRedirect(redirectURL);
                 }
                 catch (IOException ex){
                     //Copy Project Error
@@ -104,8 +120,10 @@ public class TranscribeRouter extends HttpServlet {
                     er = true;
                     System.out.println(sb.toString());
                 }
-                connection.disconnect();
-                
+                finally{
+                    connection.disconnect();
+                }
+                */
             }
         } 
         else {

--- a/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
@@ -1,0 +1,120 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/JSP_Servlet/Servlet.java to edit this template
+ */
+package edu.slu.tpen.servlet;
+
+import edu.slu.util.ServletUtils;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import textdisplay.Project;
+import user.User;
+
+/**
+ *
+ * @author bhaberbe
+ */
+public class TranscribeRouter extends HttpServlet {
+
+    /**
+     * Processes requests for both HTTP <code>GET</code> and <code>POST</code>
+     * methods.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    protected void processRequest(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException, SQLException {
+        System.out.println("In /transcribe router");
+        String paleoObj = "";
+        int uid = ServletUtils.getUID(req, resp);
+        boolean skip = true;
+        //If you choose not to automatically skip, put some method here to define what makes skip true.
+        resp.addHeader("Access-Control-Allow-Origin", "*");
+        resp.addHeader("Access-Control-Allow-Methods", "GET");
+        System.out.println("UID detected is "+uid);
+        if (uid >= 0) {
+            paleoObj = req.getPathInfo().substring(1);
+            System.out.println("Name of proj is '"+paleoObj+"'");
+            //paleoObj = req.getParameter("name");
+            User lookup = new User(uid);
+            Project proj = lookup.getUserProjectForPaleoObject(paleoObj);         
+            if (null != proj && proj.getProjectID() > 0) {
+                //Then this user has a project already.  Redirect to that project.
+                System.out.println("Found existing project for user: "+proj.getProjectID());
+                int folioNum = proj.firstPage();
+                String interfaceLink = "";
+                if(folioNum > -1){
+                   interfaceLink = proj.mintInterfaceLinkFromFolio(folioNum);
+                }
+                String redirectURL = "http://paleo.rerum.io/TPEN-NL/"+interfaceLink;
+                resp.sendRedirect(redirectURL);
+            } 
+            else{
+                //This user did not have a project yet.  Get the master project ID, run /copyProject, and redirect to the resulting link
+                System.out.println("TODO run copy project and redirect to resulting ID");  
+                resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            }
+        } 
+        else {
+            /* They need to be logged into T-PEN to run this! */
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
+    /**
+     * Handles the HTTP <code>GET</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            processRequest(request, response);
+        } catch (SQLException ex) {
+            Logger.getLogger(TranscribeRouter.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    /**
+     * Handles the HTTP <code>POST</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            processRequest(request, response);
+        } catch (SQLException ex) {
+            Logger.getLogger(TranscribeRouter.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    /**
+     * Returns a short description of the servlet.
+     *
+     * @return a String containing servlet description
+     */
+    @Override
+    public String getServletInfo() {
+        return "Short description";
+    }// </editor-fold>
+
+}

--- a/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
@@ -61,9 +61,11 @@ public class TranscribeRouter extends HttpServlet {
         if (uid >= 0) {
             projectName = req.getPathInfo().substring(1);
             User lookup = new User(uid);
+            System.out.println("Look up user project '"+projectName+"'");
             proj = lookup.getUserProjectForPaleoObject(projectName);         
             if (null != proj && proj.getProjectID() > 0) {
                 //Then this user has a project already.  Redirect to that project.
+                System.out.println("Route to user project "+proj.getProjectID());
                 folioNum = proj.firstPage();
                 if(folioNum > -1){
                    interfaceLink = proj.mintInterfaceLinkFromFolio(folioNum);
@@ -76,6 +78,7 @@ public class TranscribeRouter extends HttpServlet {
             } 
             else{
                 //This user did not have a project yet.  Get the master project ID, run /copyProject, and redirect to the resulting link
+                System.out.println("User does not have a project by this name.  Make a new one for them by copying the master");
                 int masterID = Project.getMasterProjectID(projectName);
                 int copiedProjectID = copyProjectAndLineParsing(uid, masterID, req.getLocalName());
                 if(copiedProjectID > 0){

--- a/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
@@ -61,11 +61,10 @@ public class TranscribeRouter extends HttpServlet {
         if (uid >= 0) {
             projectName = req.getPathInfo().substring(1);
             User lookup = new User(uid);
-            System.out.println("Look up user project '"+projectName+"'");
-            proj = lookup.getUserProjectForPaleoObject(projectName);         
+            proj = lookup.getUserProjectByProjectName(projectName);         
             if (null != proj && proj.getProjectID() > 0) {
                 //Then this user has a project already.  Redirect to that project.
-                System.out.println("Route to user project "+proj.getProjectID());
+                //System.out.println("Route to user project "+proj.getProjectID());
                 folioNum = proj.firstPage();
                 if(folioNum > -1){
                    interfaceLink = proj.mintInterfaceLinkFromFolio(folioNum);
@@ -78,7 +77,7 @@ public class TranscribeRouter extends HttpServlet {
             } 
             else{
                 //This user did not have a project yet.  Get the master project ID, run /copyProject, and redirect to the resulting link
-                System.out.println("User does not have a project by this name.  Make a new one for them by copying the master");
+                System.out.println("User does not have a project with name '"+projectName+"'.  Make a new one for them by copying the master");
                 int masterID = Project.getMasterProjectID(projectName);
                 int copiedProjectID = copyProjectAndLineParsing(uid, masterID, req.getLocalName());
                 if(copiedProjectID > 0){
@@ -151,15 +150,17 @@ public class TranscribeRouter extends HttpServlet {
      */
     @Override
     public String getServletInfo() {
-        return "Short description";
+        return "Functions as a router through the url patter /transcribe/{projectName}.  "
+            + "If a user has a project by that projectName, they are redirect into the transcription interface for it.  "
+            + "If not, a copy of the master project is created and they are redirected to the transcription interface for the new project.";
     }// </editor-fold>
 
     /**
-     * Same logic as the copyProjectAndTranscription Servlet
+     * Same logic as the copyProjectAndTranscription Servlet.  Returns -1 upon failures.
      * @param uID
      * @param projectID
      * @param localName
-     * @return 
+     * @return Integer result
      */
     private int copyProjectAndTranscription(int uID, int projectID, String localName){
         int result = -1;
@@ -357,11 +358,11 @@ public class TranscribeRouter extends HttpServlet {
     }
     
     /**
-     * Same logic as the copyProjectAndTranscription servlet
+     * Same logic as the copyProjectAndTranscription servlet.  Returns -1 upon failures.
      * @param uID
      * @param projectID
      * @param localName
-     * @return 
+     * @return Integer result
      */
     private int copyProjectAndLineParsing(int uID, int projectID, String localName){
         int result = -1;

--- a/Source Packages/java/textdisplay/Project.java
+++ b/Source Packages/java/textdisplay/Project.java
@@ -1702,5 +1702,27 @@ public class Project {
         return interfaceLink;
    }
    
+   public static int getMasterProjectID(String projName) throws SQLException{
+        String query = "SELECT MIN(id) FROM projects WHERE name=?";
+        Connection j = null;
+        PreparedStatement ps=null;
+        int id = -1;
+        try{
+            j = DatabaseWrapper.getConnection();
+            ps = j.prepareStatement(query);
+            ps.setString(1, projName);
+            ResultSet rs = ps.executeQuery();
+            Project p = null;
+            if(rs.next()){
+                id = rs.getInt("project.id");
+            }
+            return id;
+        } 
+        finally{
+            DatabaseWrapper.closeDBConnection(j);
+            DatabaseWrapper.closePreparedStatement(ps);
+        }
+   }
+   
    private static final Logger LOG = Logger.getLogger(Project.class.getName());
 }

--- a/Source Packages/java/textdisplay/Project.java
+++ b/Source Packages/java/textdisplay/Project.java
@@ -1729,8 +1729,9 @@ public class Project {
             if(rs.next()){
                 //Result set is one row with one column with the id we are looking for
                 id = rs.getInt(1);
+                System.out.println("Found master id: "+id);
             }
-            return -1;
+            return id;
         } 
         finally{
             DatabaseWrapper.closeDBConnection(j);

--- a/Source Packages/java/textdisplay/Project.java
+++ b/Source Packages/java/textdisplay/Project.java
@@ -1703,7 +1703,7 @@ public class Project {
    }
    
    public static int getMasterProjectID(String projName) throws SQLException{
-        String query = "SELECT MIN(id) FROM projects WHERE name=?";
+        String query = "SELECT MIN(id) FROM project WHERE name=?";
         Connection j = null;
         PreparedStatement ps=null;
         int id = -1;
@@ -1714,7 +1714,8 @@ public class Project {
             ResultSet rs = ps.executeQuery();
             Project p = null;
             if(rs.next()){
-                id = rs.getInt("project.id");
+                //Result set is one row with one column with the id we are looking for
+                id = rs.getInt(1);
             }
             return id;
         } 

--- a/Source Packages/java/textdisplay/Project.java
+++ b/Source Packages/java/textdisplay/Project.java
@@ -389,7 +389,6 @@ public class Project {
          name = "new project";
       }
       try (PreparedStatement stmt = conn.prepareStatement("insert into project (name, grp, schemaURL,linebreakCharacterLimit ) values(?,?,'',5000)", PreparedStatement.RETURN_GENERATED_KEYS)) {
-         System.out.println("generate new Project with name "+name);
          stmt.setString(1, name);
          stmt.setInt(2, group);
          stmt.execute();

--- a/Source Packages/java/user/User.java
+++ b/Source Packages/java/user/User.java
@@ -1032,6 +1032,38 @@ DatabaseWrapper.closeDBConnection(j);
 DatabaseWrapper.closePreparedStatement(ps);
             }
         }
+    
+    /**
+     * Return an array of all projects this user is a member of with name equal to the paleography object id.
+     * @return array of projects
+     * @throws SQLException
+     */
+
+    public Project getUserProjectForPaleoObject(String paleoID) throws SQLException{
+        new ProjectPriority(UID).verifyPriorityContents();
+        String query = "select distinct(project.id) from project where name=? join groupmembers on grp=GID join projectpriorities on id=projectID where groupmembers.UID=? and projectpriorities.uid=?";
+        Connection j = null;
+        PreparedStatement ps=null;
+        try{
+            j = DatabaseWrapper.getConnection();
+            ps = j.prepareStatement(query);
+            ps.setString(1, paleoID);
+            ps.setInt(2, UID);
+            ps.setInt(3, UID);
+            ResultSet rs = ps.executeQuery();
+            Project p = null;
+            if(rs.next()){
+                p = new Project(rs.getInt("project.id"));
+            }
+            return p;
+        } 
+        finally{
+            DatabaseWrapper.closeDBConnection(j);
+            DatabaseWrapper.closePreparedStatement(ps);
+        }
+    }
+    
+    
 
     /**
      * Returns a dropdown of all the users who have work that can be reviewed
@@ -1341,4 +1373,11 @@ PreparedStatement qry=null;
         }
     }
     
+    public int getUserProjectFromPaleoID(String paleoID){
+        String query = "select id from projects where UID=?";
+        return 1;
     }
+    
+}
+    
+    

--- a/Source Packages/java/user/User.java
+++ b/Source Packages/java/user/User.java
@@ -1041,15 +1041,15 @@ DatabaseWrapper.closePreparedStatement(ps);
 
     public Project getUserProjectForPaleoObject(String paleoID) throws SQLException{
         new ProjectPriority(UID).verifyPriorityContents();
-        String query = "select distinct(project.id) from project where name=? join groupmembers on grp=GID join projectpriorities on id=projectID where groupmembers.UID=? and projectpriorities.uid=?";
+        String query = "select distinct(project.id) from project join groupmembers on grp=GID join projectpriorities on id=projectID where groupmembers.UID=? and projectpriorities.uid=? and project.name=?";
         Connection j = null;
         PreparedStatement ps=null;
         try{
             j = DatabaseWrapper.getConnection();
             ps = j.prepareStatement(query);
-            ps.setString(1, paleoID);
+            ps.setInt(1, UID);
             ps.setInt(2, UID);
-            ps.setInt(3, UID);
+            ps.setString(3, paleoID);
             ResultSet rs = ps.executeQuery();
             Project p = null;
             if(rs.next()){

--- a/Source Packages/java/user/User.java
+++ b/Source Packages/java/user/User.java
@@ -1373,11 +1373,6 @@ PreparedStatement qry=null;
         }
     }
     
-    public int getUserProjectFromPaleoID(String paleoID){
-        String query = "select id from projects where UID=?";
-        return 1;
-    }
-    
 }
     
     

--- a/Source Packages/java/user/User.java
+++ b/Source Packages/java/user/User.java
@@ -1039,7 +1039,7 @@ DatabaseWrapper.closePreparedStatement(ps);
      * @throws SQLException
      */
 
-    public Project getUserProjectForPaleoObject(String paleoID) throws SQLException{
+    public Project getUserProjectByProjectName(String projectName) throws SQLException{
         new ProjectPriority(UID).verifyPriorityContents();
         String query = "select distinct(project.id) from project join groupmembers on grp=GID join projectpriorities on id=projectID where groupmembers.UID=? and projectpriorities.uid=? and project.name=?";
         Connection j = null;
@@ -1049,7 +1049,7 @@ DatabaseWrapper.closePreparedStatement(ps);
             ps = j.prepareStatement(query);
             ps.setInt(1, UID);
             ps.setInt(2, UID);
-            ps.setString(3, paleoID);
+            ps.setString(3, projectName);
             ResultSet rs = ps.executeQuery();
             Project p = null;
             if(rs.next()){

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -167,6 +167,10 @@
         <servlet-name>LoginServlet</servlet-name>
         <servlet-class>edu.slu.tpen.servlet.LoginServlet</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>TranscribeRouter</servlet-name>
+        <servlet-class>edu.slu.tpen.servlet.TranscribeRouter</servlet-class>
+    </servlet>
     <servlet-mapping>
         <servlet-name>imageResize</servlet-name>
         <url-pattern>/imageResize</url-pattern>
@@ -427,6 +431,10 @@
     <servlet-mapping>
         <servlet-name>LoginServlet</servlet-name>
         <url-pattern>/login</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>TranscribeRouter</servlet-name>
+        <url-pattern>/transcribe/*</url-pattern>
     </servlet-mapping>
     <session-config>
         <session-timeout>3000</session-timeout>


### PR DESCRIPTION
There are some dangling issues for this that need discussed.  The good news is that the core functionality works!

Trigger by using URLs like http://paleo.rerum.io/TPEN-NL/transcribe/Fables and Other Poems  (substitute in desired project name)

- We are using project.name for this, so far it has been the reliable unifying factor for the pieces of functionality required.
- The copyProject logic has been brought in as a private method.  POSTing to with did not work as expected, it could not detect the logged in user.
- The redirect loop for login stuff is not working in general, I am not sure what to do when this detects a user is not logged in.  Try to go to one of the transcription pages when not logged in, you will see what I mean.  My assumption is we want to redirect to login and provide the redirect back to /transcribe (or /interface.html), we need to go over this.
- Garbled special characters in the SQL breaks this logic chain.  It 404s because the provided title does not match the name in the db, as expected.  A proposed fix is to reimport the data correctly, that seems to be the cleanest way out.  A second idea is to just read through to mark the trouble. 
- URL encoding/decoding necessary?
- If only admins can edit master projects, we will need a way to detect that.  We need a Project.isMasterProject() function that gives us a boolean and a User.isAdmin() that gives a boolean to implement that, and we also have to work it into the transcription interface when users are trying to get into the parsing interface which means GetProjectTPENSerlvet may have to know about it.
- copyProjectAndAnnos or copyProjectAndLineParsing?