### PR TITLE
attempt to reduce lag

### DIFF
--- a/web/js/newberry.js
+++ b/web/js/newberry.js
@@ -4313,6 +4313,7 @@ function updateLine(line, cleanup, loadingLine) {
                                         var together = colLetter + lineNum;
                                         updateTranscriptionPreviewLine(together, currentLineText);
                                         lineUpdateWorking = false;
+                                        $("#lineUpdateNotice").hide();
                                     })
                                     .fail(function (responseData, status, jqXHR) {
                                         $(".trexHead").show();


### PR DESCRIPTION
Please take a look at this. There are a bunch of globals tossed in here that may cause issues I do not immediately see, but the point here is that once the line itself is saved we can move on to continue transcribing because any error in the list saving throws a trexhead.

Testing this, it looks like I have just moved the update to the presentation and the current line and all remain in scope for things like updating `[data-answer]` meaning we'll be fine for later updates.

I think if you can manage to type fast enough to change the next line and send it before the call finishes, the debounce global will prevent that save, but the next save (or 2 second pause) will still save that line.

Let me know if you have some insight that I may not be looking for.