### PR TITLE
Set Project.collection value

### DIFF
--- a/Source Packages/java/textdisplay/Project.java
+++ b/Source Packages/java/textdisplay/Project.java
@@ -1722,6 +1722,10 @@ public class Project {
         DatabaseWrapper.closePreparedStatement(ps);
    }
     
+    public String getCollection(){
+        return this.collection;
+    }
+    
     public static void setCollectionForAllProjects(){
         Connection j = null;
         PreparedStatement ps = null;


### PR DESCRIPTION
Some brute force logic inside of Project.java to set the `collection` value for every project.  It has been run, collection is set for all projects where it could be.  If Folio.getFirstPage() for a given project failed, then its collection is "".  