### PR TITLE
 Last Modified Folio (reports.jsp)

### DIFF
--- a/Source Packages/java/edu/slu/tpen/servlet/UpdateAnnoListServlet.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/UpdateAnnoListServlet.java
@@ -61,8 +61,6 @@ public class UpdateAnnoListServlet extends HttpServlet {
             JSONObject updateObject = new JSONObject();
             String content = request.getParameter("content");
             updateObject = JSONObject.fromObject(content);
-            System.out.println("Here is the update object");
-            System.out.println(updateObject);
             updateObject.element("TPEN_NL_TESTING", man.getProperties().getProperty("TESTING"));
             /**
              * This is to support reports.jsp

--- a/Source Packages/java/edu/slu/tpen/servlet/UpdateAnnoListServlet.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/UpdateAnnoListServlet.java
@@ -21,6 +21,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import net.sf.json.JSONObject;
+import textdisplay.Folio;
+import textdisplay.Project;
 import tokens.TokenManager;
 
 /**
@@ -59,7 +61,28 @@ public class UpdateAnnoListServlet extends HttpServlet {
             JSONObject updateObject = new JSONObject();
             String content = request.getParameter("content");
             updateObject = JSONObject.fromObject(content);
+            System.out.println("Here is the update object");
+            System.out.println(updateObject);
             updateObject.element("TPEN_NL_TESTING", man.getProperties().getProperty("TESTING"));
+            /**
+             * This is to support reports.jsp
+             * When a user transcribes, their update line calls will contain the current folio and project.
+             * Update the folio's lastModfiedTime with Date.now (Folio.paleography)
+             * Update the project's lastModifiedFolio with the known Folio pageNumber (Project.lastModifiedFolio)
+             * Note that reports.jsp does not expose Folio.paleography.  It was already being tracked, 
+             * so I made sure to support while I was in this code.  They used it for something, not sure what. 
+             */
+            
+            if(updateObject.containsKey("currentFolio")){
+                int folioNum = Integer.parseInt(updateObject.getString("currentFolio"));
+                Folio.setPaleographyDate(folioNum); //Track the last modified date for this folio
+                if(updateObject.containsKey("currentProject")){
+                    int projectID = Integer.parseInt(updateObject.getString("currentProject"));
+                    Project.setLastModifiedFolio(projectID, folioNum); //Track the last modified folio for this project
+                }
+            }
+            updateObject.remove("currentFolio");
+            updateObject.remove("currentProject");
             connection.connect();
             DataOutputStream out = new DataOutputStream(connection.getOutputStream());
             //value to save

--- a/Source Packages/java/textdisplay/Folio.java
+++ b/Source Packages/java/textdisplay/Folio.java
@@ -98,6 +98,7 @@ public class Folio {
    public int[] colWidths;
    public int folioNumber;
    private String archive;
+   private Date paleography;
 
    /**
     * Create a blank Folio, used internally or for creating a bean
@@ -129,6 +130,13 @@ public class Folio {
                }
             }
          }
+         try (PreparedStatement stmt2 = j.prepareStatement("select * from folios where pageNumber=?")) {
+               stmt2.setInt(1, folioNumber);
+               ResultSet rs = stmt2.executeQuery();
+               if (rs.next()) {
+                  paleography = rs.getDate("paleography");
+               }
+            }
       }
    }
 
@@ -150,6 +158,7 @@ public class Folio {
                rs = stmt2.executeQuery();
                if (rs.next()) {
                   archive = rs.getString("archive");
+                  paleography = rs.getDate("paleography");
                }
                /*
                if (linePositions.length == 0 && folioNumber > 0) {
@@ -818,6 +827,27 @@ public class Folio {
          DatabaseWrapper.closePreparedStatement(ps);
       }
       return false;
+   }
+   
+   public static void setPaleographyDate(int folioNum) throws SQLException {
+      String query = "update folios set paleography=now() where pageNumber=?";
+      Connection j = null;
+      PreparedStatement ps = null;
+      PreparedStatement del = null;
+      try {
+         j = DatabaseWrapper.getConnection();
+         ps = j.prepareStatement(query);
+         ps.setInt(1, folioNum);
+         ps.execute();
+      } finally {
+         DatabaseWrapper.closeDBConnection(j);
+         DatabaseWrapper.closePreparedStatement(ps);
+         DatabaseWrapper.closePreparedStatement(del);
+      }
+   }
+   
+   public Date getLastModifiedTime() throws SQLException {
+      return this.paleography;
    }
 
    /**

--- a/Source Packages/java/textdisplay/Project.java
+++ b/Source Packages/java/textdisplay/Project.java
@@ -979,6 +979,49 @@ public class Project {
          }
       }
    }
+   
+   public static void setLastModifiedFolio(int projectID, int folioNum) throws SQLException {
+      String query = "update project set lastModifiedFolio=? where id=?";
+      Connection j = null;
+      PreparedStatement ps = null;
+      try {
+         j = DatabaseWrapper.getConnection();
+         ps = j.prepareStatement(query);
+         ps.setInt(1, folioNum);
+         ps.setInt(2, projectID);
+         ps.execute();
+      } finally {
+         if (j != null) {
+            DatabaseWrapper.closeDBConnection(j);
+            DatabaseWrapper.closePreparedStatement(ps);
+         }
+      }
+   }
+   
+   /**
+    * Returns the Folio number of the most recently modified Folio, -1 if non exists
+    */
+   public int getLastModifiedFolio(boolean t) throws SQLException {
+      String query = "select lastModifiedFolio from project where id=?";
+      Connection j = null;
+      PreparedStatement ps = null;
+      try {
+         j = DatabaseWrapper.getConnection();
+         ps = j.prepareStatement(query);
+         ps.setInt(1, projectID);
+         ResultSet rs = ps.executeQuery();
+         if (rs.next()) {
+            return rs.getInt(1);
+         } else {
+            return -1;
+         }
+      } finally {
+         if (j != null) {
+            DatabaseWrapper.closeDBConnection(j);
+            DatabaseWrapper.closePreparedStatement(ps);
+         }
+      }
+   }
 
    /**
     * Get the parsed lines for this Folio that are specific to this Project

--- a/web/js/newberry.js
+++ b/web/js/newberry.js
@@ -4226,7 +4226,9 @@ function updateLine(line, cleanup, loadingLine) {
             "cnt:chars": currentLineText
         },
         "on": onCanvas + "#xywh=" + lineString,
-        "otherContent": []
+        "otherContent": [],
+        "currentFolio" : tpenFolios[currentFolio - 1].folioNumber,
+        "currentProject" : theProjectID
         //            "forProject": "TPEN_NL"
     };
     //cleanup is only true if parsing.  This means transcribing, but the text is the same.  no need to update.  

--- a/web/reports.jsp
+++ b/web/reports.jsp
@@ -272,7 +272,7 @@
             for (int i=0;i<numOfProjs;i++) {
                 String lastLogEntry = userProjects[i].getProjectLog(1);
                 if (lastLogEntry.length() == 0) lastLogEntry = "none recorded";
-                int lastFolioID = userProjects[i].getLastModifiedFolio();
+                int lastFolioID = userProjects[i].getLastModifiedFolio(true);
                 textdisplay.Folio lastFolio = new Folio(lastFolioID);
                 String lastFolioImg = "";
                 String lastFolioName = "";
@@ -437,7 +437,7 @@ if (request.getParameter("projects") != null) {
                     for (int i=0;i<cntProjects;i++) {
                         String lastLogEntry = allProjects[i].getProjectLog(1);
                         if (lastLogEntry.length() == 0) lastLogEntry = "none recorded";
-                        int lastFolioID = allProjects[i].getLastModifiedFolio();
+                        int lastFolioID = allProjects[i].getLastModifiedFolio(true);
                         textdisplay.Folio lastFolio = new Folio(lastFolioID);
                         String lastFolioImg = "";
                         String lastFolioName = "";


### PR DESCRIPTION
The Project table now tracks the folio id of the last modified folio.  This is detected by /updateLine and written to the database. 

 This also supports Folio.paleography, which tracks the last modified time of a given Folio.  UofT was tracking it, so I made sure it was supported in case it is part of a report they want.

See below for Last Modified Folio(Acknowledgement of Patronage)
![image](https://user-images.githubusercontent.com/3287006/139925084-7f9e01c3-6334-49bc-8251-7bac1756efd6.png)

Sel below for Folio.paleography
```SQL
mysql> select paleography from folios where pageNumber=1563;
+---------------------+
| paleography         |
+---------------------+
| 2021-11-02 13:33:00 |

```