### PR TITLE
Account for new site nav in exposed links

### DIFF
--- a/web/buttons.jsp
+++ b/web/buttons.jsp
@@ -670,7 +670,6 @@
                                                                     </ul>
                                                                     <input type="button" id="addH" name="addH" class="tpenButton ui-button" value="Add a Button" />
                                                                     <input type="submit" id="updateChars" name="update" value="Save Changes" class="tpenButton ui-button" />
-                                                                    <input type="button" id="return" name="return" value="Return to Management" onclick="document.location.href='project.jsp?projectID=<%out.print(projectID);%>';" class="tpenButton ui-button" /><br><br>
                                                                 </div>
                                                                 <div id="tabs-2">
                                                                     <div class="right" style="width:440px;">
@@ -713,11 +712,10 @@
                 }
             }
             out.print("<a class=\"returnButton\" href=\"french-transcription.html?" + pPiece + appendProject + "\">Return to Transcribing</a>");
-        %><a class="returnButton" href="project.jsp?<%out.print(projectAppend);%>">Project Management</a>
+        %>
                                                         <%
         }
         else {%>
-                                                            <a class="returnButton" href="project.jsp?<%out.print(projectAppend);%>">Return to Project Management</a>
                                                             <%}%>
                                                                 <a class="returnButton" href="my-transcriptions.html">T&#8209;PEN Home</a>
                                                 </div>

--- a/web/french-transcription.html
+++ b/web/french-transcription.html
@@ -975,7 +975,6 @@
                     if (theURL.indexOf("projectID=") > -1){
                         var projID = getURLVariable("projectID");
                         theProjectID = parseInt(projID);
-                        $(".editButtons").attr("href", "buttons.jsp?projectID="+theProjectID);
                         $("#transcriptionText").val(projID);
                         $("#loadBtn").click();
                     }

--- a/web/italian-transcription.html
+++ b/web/italian-transcription.html
@@ -940,7 +940,6 @@
                     if (theURL.indexOf("projectID=") > -1){
                         var projID = getURLVariable("projectID");
                         theProjectID = parseInt(projID);
-                        $(".editButtons").attr("href", "buttons.jsp?projectID="+theProjectID);
                         $("#transcriptionText").val(projID);
                         $("#loadBtn").click();
                     }

--- a/web/js/newberry.js
+++ b/web/js/newberry.js
@@ -5883,8 +5883,12 @@ function closeHelpVideo() {
 function setPaleographyLinks() {
     setIframeLinks();
     $("#homeBtn").attr("href", "my-transcriptions.html");
-    $("#projectsBtn").attr("href", "groupmembers.jsp?projectID=" + getURLVariable("projectID"));
-    $(".editButtons").attr("href", "buttons.jsp?projectID="+theProjectID);
+    let plink = ""
+    if (getURLVariable("p")) {
+        plink = "&p=" + getURLVariable("p");
+    }
+    $("#projectsBtn").attr("href", "groups.jsp?projectID=" + getURLVariable("projectID") + plink);
+    $(".editButtons").attr("href", "buttons.jsp?projectID="+ getURLVariable("projectID") + plink);
 }
 
 /*

--- a/web/js/newberry.js
+++ b/web/js/newberry.js
@@ -5310,10 +5310,10 @@ function updateURL(piece, classic) {
         else {
             toAddressBar = replaceURLVariable("p", tpenFolios[currentFolio - 1].folioNumber);
         }
-        var relocator = "buttons.jsp?" + "projectID=" + projectID;
+        //Also pass p to buttons.jsp
+        var relocator = "buttons.jsp?" + "projectID=" + projectID + "&p="+tpenFolios[currentFolio - 1].folioNumber;
         $(".editButtons").attr("href", relocator);
     }
-
     window.history.pushState("", "T&#8209;PEN Transcription", toAddressBar);
 }
 
@@ -5883,7 +5883,8 @@ function closeHelpVideo() {
 function setPaleographyLinks() {
     setIframeLinks();
     $("#homeBtn").attr("href", "my-transcriptions.html");
-    $("#projectsBtn").attr("href", "groups.jsp?projectID=" + getURLVariable("projectID"));
+    $("#projectsBtn").attr("href", "groupmembers.jsp?projectID=" + getURLVariable("projectID"));
+    $(".editButtons").attr("href", "buttons.jsp?projectID="+theProjectID);
 }
 
 /*


### PR DESCRIPTION
closes #183 
closes #158

The following were either performed, observed or confirmed.
- All links to 'Home' or 'My Projects' go to `my-transcriptions.html`.
- Login redirects to `my-transcription.html`.
- Logout redirects to `my-transcriptions.html`.
- `my-transcriptions.html` starts the login loop for non-logged in users.
- "Return to Management" links that redirected back to project.jsp have been removed.
- "Manage Team" goes to groupmemebers.jsp?projectID=.
- French Transcription Interface redirects to French static site for non-logged in users.
- Italian Transcription Interface redirects to Italian static site for non-logged in users.
- "p=" URL variable is in links in case we use it, not sure if we completely respect it in this TPEN iteration.
- There is no `groupmembers.jsp` in the project.