### PR TITLE
Query Against Both CanvasID Patterns

### DIFF
--- a/Source Packages/java/edu/slu/tpen/entity/Image/Canvas.java
+++ b/Source Packages/java/edu/slu/tpen/entity/Image/Canvas.java
@@ -158,7 +158,7 @@ public class Canvas {
      * @param UID: The current UID of the user in session.
      * @return : The annotation lists @id property, not the object.  Meant to look like an otherContent field.
      */
-    public static JSONArray getAnnotationListsForProject(Integer projectID, String canvasID, Integer UID, TokenManager man) throws MalformedURLException, IOException {
+    public static JSONArray getAnnotationListsForProject(Integer projectID, String canvasNum, Integer UID, TokenManager man) throws MalformedURLException, IOException {
         /*
             BH note 7/26/18
             In a traditional sense, if we find a list in v1 we don't have to check v0 anymore.  However, given the nature
@@ -187,14 +187,20 @@ public class Canvas {
         int lim = 75;
         int skip = 0;
         String serv = "/getByProperties.action?skip=" + skip + "&limit=" + lim;
-
         URL postUrl = new URL(Constant.ANNOTATION_SERVER_ADDR + serv);
         JSONObject historyWildCard = new JSONObject();
         historyWildCard.element("$exists", true);
         historyWildCard.element("$size", 0);
+        JSONArray targetVariant = new JSONArray();
+        JSONObject target1 = new JSONObject();
+        target1.element("on", man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + canvasNum);
+        JSONObject target2 = new JSONObject();
+        target2.element("on", man.getProperties().getProperty("OLD_PALEO_CANVAS_ID_PREFIX") + canvasNum);
+        targetVariant.add(target1);
+        targetVariant.add(target2);
         JSONObject parameter = new JSONObject();
         parameter.element("@type", "sc:AnnotationList");
-        parameter.element("on", canvasID);
+        parameter.element("$or", targetVariant);
         parameter.element("isPartOf", Integer.toString(projectID));
         parameter.element("__rerum.history.next", historyWildCard); //Wow this improves run time dramatically.  No need for the loop below with this. 
         //This means those that have a next because they were forked won't be found, but that shouldn't be a problem here.  

--- a/Source Packages/java/edu/slu/tpen/servlet/CopyProjectAndLineParsing.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/CopyProjectAndLineParsing.java
@@ -89,10 +89,11 @@ public class CopyProjectAndLineParsing extends HttpServlet {
                             //System.out.println("Starting copy for canvas");
                             Folio folio = folios[i];
                             String imageURL = folio.getImageURL();
+                            String canvasNum = imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1");
                             // use regex to extract paleography pid
                             //THIS MUST MATCH THE NAMING CONVENTION IN JSONLDEXporter
                             String canvasID = man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1"); //for paleo
-                            JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasID, uID, man);
+                            JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasNum, uID, man);
                             JSONObject jo_annotationList = new JSONObject();
                             //^^ this does all the filtering and will either have 0 or 1 lists for this particular version of TPEN
                             if(!ja_allAnnoLists.isEmpty()){

--- a/Source Packages/java/edu/slu/tpen/servlet/CopyProjectAndTranscription.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/CopyProjectAndTranscription.java
@@ -91,10 +91,11 @@ public class CopyProjectAndTranscription extends HttpServlet {
                             //System.out.println("Starting copy for canvas");
                             Folio folio = folios[i];
                             String imageURL = folio.getImageURL();
+                            String canvasNum = imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1");
                             // use regex to extract paleography pid
                             //THIS MUST MATCH THE NAMING CONVENTION IN JSONLDEXporter
                             String canvasID = man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1"); //for paleo
-                            JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasID, uID, man);
+                            JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasNum, uID, man);
                             JSONObject jo_annotationList = new JSONObject();
                             //^^ this does all the filtering and will either have 0 or 1 lists for this particular version of TPEN
                             if(!ja_allAnnoLists.isEmpty()){

--- a/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
+++ b/Source Packages/java/edu/slu/tpen/servlet/TranscribeRouter.java
@@ -191,10 +191,11 @@ public class TranscribeRouter extends HttpServlet {
                         //System.out.println("Starting copy for canvas");
                         Folio folio = folios[i];
                         String imageURL = folio.getImageURL();
+                        String canvasNum = imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1");
                         // use regex to extract paleography pid
                         //THIS MUST MATCH THE NAMING CONVENTION IN JSONLDEXporter
                         String canvasID = man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1"); //for paleo
-                        JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasID, uID, man);
+                        JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasNum, uID, man);
                         JSONObject jo_annotationList = new JSONObject();
                         //^^ this does all the filtering and will either have 0 or 1 lists for this particular version of TPEN
                         if(!ja_allAnnoLists.isEmpty()){
@@ -391,10 +392,11 @@ public class TranscribeRouter extends HttpServlet {
                         //System.out.println("Starting copy for canvas");
                         Folio folio = folios[i];
                         String imageURL = folio.getImageURL();
+                        String canvasNum = imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1");
                         // use regex to extract paleography pid
                         //THIS MUST MATCH THE NAMING CONVENTION IN JSONLDEXporter
                         String canvasID = man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + imageURL.replaceAll("^.*(paleography[^/]+).*$", "$1"); //for paleo
-                        JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasID, uID, man);
+                        JSONArray ja_allAnnoLists = Canvas.getAnnotationListsForProject(projectID, canvasNum, uID, man);
                         JSONObject jo_annotationList = new JSONObject();
                         //^^ this does all the filtering and will either have 0 or 1 lists for this particular version of TPEN
                         if(!ja_allAnnoLists.isEmpty()){

--- a/Source Packages/java/edu/slu/tpen/transfer/JsonLDExporter.java
+++ b/Source Packages/java/edu/slu/tpen/transfer/JsonLDExporter.java
@@ -138,8 +138,8 @@ public class JsonLDExporter {
         System.out.println("Folio Number: "+f.getFolioNumber());
         System.out.println("Folio URL Resize: "+f.getImageURLResize());
        */
-        
-        String canvasID = man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + f.getImageURL().replaceAll("^.*(paleography[^/]+).*$", "$1"); //for paleo dev and prod
+        String canvasNum = f.getImageURL().replaceAll("^.*(paleography[^/]+).*$", "$1");
+        String canvasID = man.getProperties().getProperty("PALEO_CANVAS_ID_PREFIX") + canvasNum; //for paleo dev and prod
         //String canvasID = projName + "/canvas/" + URLEncoder.encode(f.getPageName(), "UTF-8"); //For SLU testing    
         
         DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS");
@@ -188,7 +188,7 @@ public class JsonLDExporter {
 
         JSONArray otherContent = new JSONArray();
         Date date4 = new Date();
-        otherContent = Canvas.getAnnotationListsForProject(projID, canvasID, u.getUID(), man);
+        otherContent = Canvas.getAnnotationListsForProject(projID, canvasNum, u.getUID(), man);
         Date date5 = new Date();
         //System.out.println("++++++++++++++++++++++++++++++++++");
         //System.out.println("It took "+getDateDiff(date4,date5,TimeUnit.SECONDS)+" seconds to get the list for this page");

--- a/Source Packages/java/tokens/TokenManager.java
+++ b/Source Packages/java/tokens/TokenManager.java
@@ -34,6 +34,7 @@ public class TokenManager{
     private String currentRefreshToken = "";
     private String registeredAgent = "";
     private String canvasPrefix = "";
+    private String oldCanvasPrefix = "";
     private String propFileLocation = "";
     private String testingFlag = "";
     private String database = "";
@@ -71,6 +72,7 @@ public class TokenManager{
         currentRefreshToken = props.getProperty("TPEN_NL_REFRESH_TOKEN");
         registeredAgent = props.getProperty("TPEN_NL_AGENT");
         canvasPrefix = props.getProperty("PALEO_CANVAS_ID_PREFIX");
+        oldCanvasPrefix = props.getProperty("OLD_PALEO_CANVAS_ID_PREFIX");
         testingFlag = props.getProperty("TESTING");
         database = props.getProperty("DATABASE");
         dbuser = props.getProperty("DBUSER");
@@ -297,6 +299,10 @@ public class TokenManager{
         canvasPrefix = newPrefix;
     }
     
+    public void setOldCanvasPrefix(String newPrefix){
+        oldCanvasPrefix = newPrefix;
+    }
+    
     public void setTestingFlag(String bool){
         testingFlag = bool;
     }
@@ -319,6 +325,10 @@ public class TokenManager{
     
     public String getCanvasPrefix(){
         return canvasPrefix;
+    }
+    
+    public String getOldCanvasPrefix(){
+        return oldCanvasPrefix;
     }
     
     public String getTestingFlag(){


### PR DESCRIPTION
We could do this instead of updating the MongoDB objects.  This worked for the projects I tested against, which was not all of them of course.  Going forward, the `on` property will have the new pattern.